### PR TITLE
Bump version to 1.5

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ import os
 
 class sqlite_ormConan(ConanFile):
     name = "sqlite_orm"
-    version = "1.4"
+    version = "1.5"
     description = "SQLite ORM light header only library for modern C++."
     url = "https://github.com/bincrafters/conan-sqlite_orm"
     homepage = "https://github.com/fnc12/sqlite_orm"


### PR DESCRIPTION
A new [release](https://github.com/fnc12/sqlite_orm/releases/tag/v1.5) is available since December 2019.